### PR TITLE
Ignores comments when using zsh

### DIFF
--- a/flask_crontab.py
+++ b/flask_crontab.py
@@ -92,15 +92,17 @@ class _CronJob:
             if os.getenv("FLASK_APP")
             else ""
         )
-        crontab_comment = "Flask cron jobs for {}".format(current_app.name)
-        line = "{} cd {} && {}{} crontab run {}  # {}".format(
+        using_zsh = os.environ.get('SHELL', '').endswith('/zsh')
+        line = "{} cd {} && {}{} crontab run {}".format(
             self.schedule,
             os.getcwd(),
             env_prefix,
             flask_bin,
             self.hash,
-            crontab_comment,
         )
+        if not using_zsh:
+            crontab_comment = "Flask cron jobs for {}".format(current_app.name)
+            line += '  # ' + crontab_comment
         return line
 
 


### PR DESCRIPTION
this addresses issue #2 by only adding the comment to the crontab line if the shell isn't using zsh.

this shouldn't have a bearing on most users when deploying their software, but local testing will be easier

I ran `python setup.py develop` from this project to package it and ran `pip install ../flask-crontab` from my project's directory to install the package and have verified that it's now working